### PR TITLE
Initial JSON published stream to Message Hub conversion microservice

### DIFF
--- a/com.ibm.streamsx.microservice/com.ibm.streamsx.microservice.convert.services/jsontohub.spl
+++ b/com.ibm.streamsx.microservice/com.ibm.streamsx.microservice.convert.services/jsontohub.spl
@@ -17,8 +17,8 @@ use com.ibm.streamsx.topology.topic::Subscribe;
 
   @param messageHub Name of application configuration containing
      Message Hub credentials.
-  @param topicPattern Topic pattern to match. All topics that match
-     the pattern will result in messages sent to the `producerTopic`
+  @param topicFilter Topic filter to match. All topics that match
+     `topicFilter` will result in messages sent to the `producerTopic`
      on Message Hub.
   @param producerTopic Message Hub topic the messages will be submitted to.
 */
@@ -26,14 +26,14 @@ public composite JSONToMessageHubService {
 
   param
     expression<rstring> $messageHub : getSubmissionTimeValue("messageHub", "messagehub");
-    expression<rstring> $topicPattern : getSubmissionTimeValue("topicPattern");
+    expression<rstring> $topicFilter : getSubmissionTimeValue("topicFilter");
     expression<rstring> $producerTopic : getSubmissionTimeValue("producerTopic");
 
   graph
 
     stream<Json> Stream = Subscribe() {
       param
-        topic: $topicPattern;
+        topic: $topicFilter;
         streamType: Json;
     }
 	

--- a/com.ibm.streamsx.microservice/com.ibm.streamsx.microservice.convert.services/jsontohub.spl
+++ b/com.ibm.streamsx.microservice/com.ibm.streamsx.microservice.convert.services/jsontohub.spl
@@ -1,0 +1,49 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2017
+*/
+
+namespace com.ibm.streamsx.microservice.convert.services;
+
+use com.ibm.streamsx.messagehub::MessageHubProducer;
+use com.ibm.streamsx.json::Json;
+use com.ibm.streamsx.topology.topic::Subscribe;
+
+/**
+  Convert JSON published topic streams to a message hub topic.
+
+  Streaming microservice that converts published stream topics to a messages
+  on a Message Hub topic. For each tuple published a message is submitted.
+
+  @param messageHub Name of application configuration containing
+     Message Hub credentials.
+  @param topicPattern Topic pattern to match. All topics that match
+     the pattern will result in messages sent to the `producerTopic`
+     on Message Hub.
+  @param producerTopic Message Hub topic the messages will be submitted to.
+*/
+public composite JSONToMessageHubService {
+
+  param
+    expression<rstring> $messageHub : getSubmissionTimeValue("messageHub", "messagehub");
+    expression<rstring> $topicPattern : getSubmissionTimeValue("topicPattern");
+    expression<rstring> $producerTopic : getSubmissionTimeValue("producerTopic");
+
+  graph
+
+    stream<Json> Stream = Subscribe() {
+      param
+        topic: $topicPattern;
+        streamType: Json;
+    }
+	
+    () as Submitter = MessageHubProducer(Stream) {
+      param
+        messageAttribute: jsonString;
+        topic: $producerTopic;
+        appConfigName: $messageHub;
+    } 
+
+  config
+    placement: partitionColocation("SinglePE");
+}

--- a/com.ibm.streamsx.microservice/com.ibm.streamsx.microservice.convert.services/namespace-info.spl
+++ b/com.ibm.streamsx.microservice/com.ibm.streamsx.microservice.convert.services/namespace-info.spl
@@ -1,0 +1,18 @@
+/*
+# Licensed Materials - Property of IBM
+# Copyright IBM Corp. 2017
+*/
+
+/**
+   Streaming microservices supporting conversions
+   to and from published streams.
+
+   Conversions may be added to support:
+
+   * Conversion from a published stream to/from a Message Hub (Kakfa) queue.
+   * Conversion from an SPL/structured published stream to/from a JSON stream.
+   * Conversion from one version of a published stream to another.
+
+*/
+
+namespace com.ibm.streamsx.microservice.convert.services;

--- a/com.ibm.streamsx.microservice/info.xml
+++ b/com.ibm.streamsx.microservice/info.xml
@@ -3,8 +3,22 @@
   <info:identity>
     <info:name>com.ibm.streamsx.microservice</info:name>
     <info:description>Streaming microservice support.</info:description>
-    <info:version>0.0.0</info:version>
+    <info:version>0.1.0</info:version>
     <info:requiredProductVersion>4.2.0</info:requiredProductVersion>
   </info:identity>
-  <info:dependencies/>
+  <info:dependencies>
+    <info:toolkit>
+      <common:name>com.ibm.streamsx.messagehub</common:name>
+      <common:version>[1.2.2,2.0)</common:version>
+    </info:toolkit>
+    <info:toolkit>
+      <common:name>com.ibm.streamsx.topology</common:name>
+      <common:version>[1.6,2.0)</common:version>
+    </info:toolkit>
+    <info:toolkit>
+      <common:name>com.ibm.streamsx.json</common:name>
+      <common:version>[1.3,2.0)</common:version>
+    </info:toolkit>
+  </info:dependencies>
+
 </info:toolkitInfoModel>


### PR DESCRIPTION
A service that converts published streams with the standard `Json` schema to Message Hub messages.

I use this to bridge the gap between Streams applications running on Streaming Analytics on IBM Cloud and the new just beta'ed Streams Designer.

Thus through MessageHub a Stream Designer flow can consume streams produced by regular Streams applications.

https://medium.com/ibm-data-science-experience/introducing-streams-designer-81c6ee313dd1